### PR TITLE
Add admin user (#186)

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -61,7 +61,7 @@ class ProjectsController < ApplicationController
   end
 
   def require_owner
-    unless @project.author_id == current_user.id
+    unless (@project.author_id == current_user.id) | (current_user.admin_role?)
       redirect_to root_path
       flash[:alert] = 'Restricted action, must own project.'
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,8 @@ class User < ApplicationRecord
   validates :name, presence: true
   validates :affiliation, presence: true
 
+  enum role: { public: 'public', admin: 'admin' }, _suffix: true
+
   def self.find_first_by_auth_conditions(warden_conditions)
     conditions = warden_conditions.dup
     if login = conditions.delete(:login)

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -47,7 +47,7 @@
 
   <div data-latitude="<%= @project.lonlat.y %>" data-longitude="<%= @project.lonlat.x %>" id="map" class="rounded border border-secondary"></div>
 
-  <% if user_signed_in? && @project.author_id == current_user.id %>
+  <% if user_signed_in? && (@project.author_id == current_user.id || current_user.admin_role?) %>
   <hr />
   <div class="btn-group">
     <%= link_to 'Edit', edit_project_path(@project), class: 'btn btn-primary', title: "Edit #{@project}" %>

--- a/db/migrate/20220121053859_add_role_to_users.rb
+++ b/db/migrate/20220121053859_add_role_to_users.rb
@@ -1,0 +1,15 @@
+class AddRoleToUsers < ActiveRecord::Migration[5.2]
+  def up
+    execute <<-SQL
+      CREATE TYPE user_role AS ENUM ('public', 'admin');
+    SQL
+    add_column :users, :role, :user_role, default: 'public'
+  end
+
+  def down
+    remove_column :users, :role
+    execute <<-SQL
+      DROP TYPE user_role;
+    SQL
+  end
+end


### PR DESCRIPTION
In preparation of switching from paperclip to Active Storage for images, adding an admin role to allow for re-uploading the old images again, since they will be lost upon the transition.

* Added role enum attribute to User model

* Added project CRUD permissions to admin

* Admins now see edit/delete buttons on project page