### PR TITLE
239 organizations permissions

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,7 +1,7 @@
 class OrganizationsController < ApplicationController
   before_action :set_organization, only: %w[ show edit update destroy ]
   before_action :authenticate_user!, except: [:show, :index]
-  before_action :require_admin, only: [:edit, :show, :new, :create, :update, :destroy]
+  before_action :require_admin, only: [:edit, :new, :create, :update, :destroy]
 
   # GET /organizations
   # GET /organizations.json
@@ -75,9 +75,9 @@ class OrganizationsController < ApplicationController
     end
 
     def require_admin
-        unless current_user.admin_role?
+        unless current_user.admin_role
           redirect_to root_path
-          flash[:alert] = 'Restricted action, must be an admin'
+          flash[:alert] = 'Restricted action, must be an Admin'
         end
     end
 end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -79,5 +79,5 @@ class OrganizationsController < ApplicationController
           redirect_to root_path
           flash[:alert] = 'Restricted action, must be an admin'
         end
-      end
+    end
 end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,7 +1,7 @@
 class OrganizationsController < ApplicationController
   before_action :set_organization, only: %w[ show edit update destroy ]
   before_action :authenticate_user!, except: [:show, :index]
-  before_action :require_admin, only: [:edit, :show, :create, :update, :destroy]
+  before_action :require_admin, only: [:edit, :show, :new, :create, :update, :destroy]
 
   # GET /organizations
   # GET /organizations.json

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,7 +1,7 @@
 class OrganizationsController < ApplicationController
   before_action :set_organization, only: %w[ show edit update destroy ]
   before_action :authenticate_user!, except: [:show, :index]
-  before_action :require_admin, only: [:edit, :new, :create, :update, :destroy]
+  before_action :require_admin, only: [:edit, :new, :create, :update, :destroy], except: [:show, :index]
 
   # GET /organizations
   # GET /organizations.json
@@ -75,7 +75,7 @@ class OrganizationsController < ApplicationController
     end
 
     def require_admin
-        unless current_user.admin_role
+        unless current_user.admin_role?
           redirect_to root_path
           flash[:alert] = 'Restricted action, must be an Admin'
         end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,5 +1,7 @@
 class OrganizationsController < ApplicationController
   before_action :set_organization, only: %w[ show edit update destroy ]
+  before_action :authenticate_user!, except: [:show, :index]
+  before_action :require_admin, only: [:edit, :update, :destroy]
 
   # GET /organizations
   # GET /organizations.json
@@ -71,4 +73,11 @@ class OrganizationsController < ApplicationController
     def organization_params
         params.require(:organization).permit(:name, :description, :contact, :website, :icon)
     end
+
+    def require_admin
+        unless current_user.admin_role?
+          redirect_to root_path
+          flash[:alert] = 'Restricted action, must be an admin'
+        end
+      end
 end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -75,7 +75,7 @@ class OrganizationsController < ApplicationController
     end
 
     def require_admin
-        unless current_user.admin_role?
+        unless current_user.admin_role
           redirect_to root_path
           flash[:alert] = 'Restricted action, must be an Admin'
         end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,7 +1,7 @@
 class OrganizationsController < ApplicationController
   before_action :set_organization, only: %w[ show edit update destroy ]
   before_action :authenticate_user!, except: [:show, :index]
-  before_action :require_admin, only: [:edit, :update, :destroy]
+  before_action :require_admin, only: [:edit, :show, :create, :update, :destroy]
 
   # GET /organizations
   # GET /organizations.json

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-expand-md navbar-dark bg-dark navbar-fixed-top sticky">
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark navbar-fixed-top sticky">
   <%= link_to root_path, :class => 'logo', title: 'BDA Explorer home' do %>
   LT-PBR
   <span id="logo-highlight">explorer</span>
@@ -11,6 +11,12 @@
       <li class="nav-item active">
         <div class="nav-link">
           <%= link_to 'About', about_path %>
+        </div>
+        <span class="sr-only">(current)</span>
+      </li>
+      <li class="nav-item active">
+        <div class="nav-link">
+          <%= link_to 'Organizations', organizations_path %>
         </div>
         <span class="sr-only">(current)</span>
       </li>

--- a/app/views/organizations/_organization.html.erb
+++ b/app/views/organizations/_organization.html.erb
@@ -12,8 +12,10 @@
     <h5 class="text-secondary"><%= html_url%></h5>
   </div>
   <br>
-  <div class="col-sm-3">
-    <%= link_to 'Edit', edit_organization_path(organization), class: "btn btn-success", id: "filter-button" %>
-    <%= link_to 'Destroy', organization, class: "btn btn-success", id: "filter-button", method: :delete, data: { confirm: 'Are you sure?' } %>
+  <% if current_user.admin_role %>
+    <div class="col-sm-3">
+        <%= link_to 'Edit', edit_organization_path(organization), class: "btn btn-success", id: "filter-button" %>
+        <%= link_to 'Destroy', organization, class: "btn btn-success", id: "filter-button", method: :delete, data: { confirm: 'Are you sure?' } %>
     </div>
+  <% end %>
 </div>

--- a/app/views/organizations/_organization.html.erb
+++ b/app/views/organizations/_organization.html.erb
@@ -12,7 +12,7 @@
     <h5 class="text-secondary"><%= html_url%></h5>
   </div>
   <br>
-  <% if current_user.admin_role %>
+  <% if current_user && current_user.admin_role %>
     <div class="col-sm-3">
         <%= link_to 'Edit', edit_organization_path(organization), class: "btn btn-success", id: "filter-button" %>
         <%= link_to 'Destroy', organization, class: "btn btn-success", id: "filter-button", method: :delete, data: { confirm: 'Are you sure?' } %>

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -5,9 +5,11 @@
     <div class="col">
       <h1>Organizations</h1>
     </div>
+    <% if current_user.admin_role %>
     <div class="col text-right">
       <%= link_to 'New Organization', new_organization_path, class: "btn btn-success", id: "filter-button" %>
     </div>
+    <% end %>
   </div>
 <%= render @organizations%>
 <hr>

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -5,7 +5,7 @@
     <div class="col">
       <h1>Organizations</h1>
     </div>
-    <% if current_user.admin_role %>
+    <% if current_user && current_user.admin_role %>
     <div class="col text-right">
       <%= link_to 'New Organization', new_organization_path, class: "btn btn-success", id: "filter-button" %>
     </div>

--- a/db/migrate/20220419170243_add_admin_role_to_user.rb
+++ b/db/migrate/20220419170243_add_admin_role_to_user.rb
@@ -1,0 +1,5 @@
+class AddAdminRoleToUser < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :admin_role, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_04_14_010437) do
+ActiveRecord::Schema[7.0].define(version: 2022_04_19_170243) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -78,6 +78,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_04_14_010437) do
     t.datetime "updated_at", precision: nil, null: false
     t.geography "lonlat", limit: {:srid=>4326, :type=>"st_point", :geographic=>true}, null: false
     t.integer "author_id", null: false
+    t.string "photo_file_name"
+    t.string "photo_content_type"
+    t.integer "photo_file_size"
+    t.datetime "photo_updated_at", precision: nil
     t.integer "number_of_structures", null: false
     t.text "structure_description", null: false
     t.string "name", null: false
@@ -114,6 +118,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_04_14_010437) do
     t.string "affiliation", null: false
     t.string "name", null: false
     t.enum "role", default: "public", enum_type: "user_role"
+    t.boolean "admin_role", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
Added proper admin permissions to Organizations. Users with the admin role can create, update, destroy organizations. Users can still view index and show. Navigation to organizations added too. 