### PR TITLE
Remove admin_role and update to use existing role

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -75,7 +75,7 @@ class OrganizationsController < ApplicationController
     end
 
     def require_admin
-        unless current_user.admin_role
+        unless current_user.admin_role?
           redirect_to root_path
           flash[:alert] = 'Restricted action, must be an Admin'
         end

--- a/app/views/organizations/_organization.html.erb
+++ b/app/views/organizations/_organization.html.erb
@@ -12,7 +12,7 @@
     <h5 class="text-secondary"><%= html_url%></h5>
   </div>
   <br>
-  <% if current_user && current_user.admin_role %>
+  <% if current_user && current_user.admin_role? %>
     <div class="col-sm-3">
         <%= link_to 'Edit', edit_organization_path(organization), class: "btn btn-success", id: "filter-button" %>
         <%= link_to 'Destroy', organization, class: "btn btn-success", id: "filter-button", method: :delete, data: { confirm: 'Are you sure?' } %>

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -5,7 +5,7 @@
     <div class="col">
       <h1>Organizations</h1>
     </div>
-    <% if current_user && current_user.admin_role %>
+    <% if current_user && current_user.admin_role? %>
     <div class="col text-right">
       <%= link_to 'New Organization', new_organization_path, class: "btn btn-success", id: "filter-button" %>
     </div>

--- a/db/migrate/20220420182337_remove_admin_role_from_users.rb
+++ b/db/migrate/20220420182337_remove_admin_role_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveAdminRoleFromUsers < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :users, :admin_role
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_04_19_170243) do
+ActiveRecord::Schema[7.0].define(version: 2022_04_20_182337) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -118,7 +118,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_04_19_170243) do
     t.string "affiliation", null: false
     t.string "name", null: false
     t.enum "role", default: "public", enum_type: "user_role"
-    t.boolean "admin_role", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
Use existing admin role feature instead of new attribute admin_role. Remove admin_role migration and swap functionality. 