### PR TITLE
239 graph tweaks

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -14,16 +14,16 @@ class OrganizationsController < ApplicationController
   # GET /organizations/1.json
   def show
     #Time window up to today to show projects on graph
-    @timestamp = 3.year.ago
+    @timestamp = 30.year.ago
     #Gather all Projects associated with this organization
     @organization_projects = @organization.projects
 
     #Group up project entries by month through implementation date, and run the accumulation function to create a cumulative graph instead 
     #of line graph. Then, reject all dates if their timestamp is greater than the currently set timestamp
-    @chart_project_count = accumulate_data(@organization_projects.group_by_month(:implementation_date, format: "%b %Y").count).keep_if { |i, _| i > @timestamp }
-    @chart_structure_count = accumulate_data(@organization_projects.group_by_month(:implementation_date).sum(:number_of_structures)).keep_if { |i, _| i > @timestamp }
+    @chart_project_count = accumulate_data(@organization_projects.group_by_day(:implementation_date, format: "%d %b %Y").count).keep_if { |i, _| i > @timestamp }
+    @chart_structure_count = accumulate_data(@organization_projects.group_by_day(:implementation_date).sum(:number_of_structures)).keep_if { |i, _| i > @timestamp }
     #Convert from m to km at the end
-    @chart_total_length = accumulate_data(@organization_projects.group_by_month(:implementation_date).sum(:length)).keep_if { |i, _| i > @timestamp }.transform_values { |v| v / 1000.0}
+    @chart_total_length = accumulate_data(@organization_projects.group_by_day(:implementation_date).sum(:length)).keep_if { |i, _| i > @timestamp }.transform_values { |v| v / 1000.0}
 
     @project_count = @organization_projects.count
     @structure_sum = @organization_projects.structure_sum

--- a/app/controllers/states_controller.rb
+++ b/app/controllers/states_controller.rb
@@ -9,14 +9,14 @@ class StatesController < ApplicationController
     gon.state_name = @state.name
     gon.rabl :template => 'app/views/shared/projects.rabl'
 
-    @timestamp = 3.year.ago
+    @timestamp = 30.year.ago
 
     #Group up project entries by month through implementation date, and run the accumulation function to create a cumulative graph instead 
     #of line graph. Then, reject all dates if their timestamp is greater than the currently set timestamp
-    @chart_project_count = accumulate_data(@projects.group_by_month(:implementation_date, format: "%b %Y").count).keep_if { |i, _| i > @timestamp }
-    @chart_structure_count = accumulate_data(@projects.group_by_month(:implementation_date).sum(:number_of_structures)).keep_if { |i, _| i > @timestamp }
+    @chart_project_count = accumulate_data(@projects.group_by_day(:implementation_date, format: "%d %b %Y").count).keep_if { |i, _| i > @timestamp }
+    @chart_structure_count = accumulate_data(@projects.group_by_day(:implementation_date).sum(:number_of_structures)).keep_if { |i, _| i > @timestamp }
     #Convert from m to km at the end
-    @chart_total_length = accumulate_data(@projects.group_by_month(:implementation_date).sum(:length)).keep_if { |i, _| i > @timestamp }.transform_values! { |v| v / 1000.0}
+    @chart_total_length = accumulate_data(@projects.group_by_day(:implementation_date).sum(:length)).keep_if { |i, _| i > @timestamp }.transform_values! { |v| v / 1000.0}
 
 
   rescue ActiveRecord::RecordNotFound

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -103,7 +103,7 @@ const myChart = new Chart(ctx, {
       scales: {
         xAxis: {
             ticks: {
-                maxTicksLimit: 5
+                maxTicksLimit: 8
             },
         },
         y: {

--- a/app/views/states/show.html.erb
+++ b/app/views/states/show.html.erb
@@ -76,7 +76,7 @@
 
   <hr />
   <div class="container">
-  <h3 class="lead text-center">Graphing <%= @state.name%>'s Projects in the Last 3 Years</h3>
+  <h3 class="lead text-center">Graphing <%= @state.name%>'s Projects from <%=@chart_project_count.keys[0] %> Onward</h3>
   <canvas id="myChart" width="400" height="200"></canvas>
   <br>
   </div>
@@ -134,7 +134,7 @@ const myChart = new Chart(ctx, {
       scales: {
         xAxis: {
             ticks: {
-                maxTicksLimit: 5
+                maxTicksLimit: 8
             },
         },
         y: {


### PR DESCRIPTION
Remove time limits on state/organization graphs. Group by day now instead of month. Increase number of ticks on x axis. 